### PR TITLE
Major changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 Todo:
 *  = javascript execution
-* text blocks
 * -inheritance stuff- +Added to keywords+
 * (javascript, css, etc.)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 Todo:
-*  = javascript execution
 * -inheritance stuff- +Added to keywords+
 * (javascript, css, etc.)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 Todo:
-* -inheritance stuff- +Added to keywords+
 * (javascript, css, etc.)
+* filters
+* interpolation
+* mixins
+* block expansion
+* Highlight JavaScript in attributes (I'm not sure this is possible without a full JS parser)
+* Code folding

--- a/jade.xml
+++ b/jade.xml
@@ -128,6 +128,7 @@ Changelog:
 		
 		<contexts>
 			<context attribute="Normal" lineEndContext="#stay" name="Normal">
+				<!--
 				<Float attribute="Float" context="#stay"/>
 				<Int attribute="Decimal" context="#stay"/>
 				<HlCOct attribute="Oct" context="#stay"/>
@@ -140,9 +141,19 @@ Changelog:
 				<RangeDetect attribute="Var" char="#" char1="}" context="#stay"/>
 				<RegExpr attribute="Id" String="#\w*" context="#stay"/>
 				<RegExpr attribute="Class" String="\.\w[^\s]*" context="#stay"/>
+				-->
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
+				<IncludeRules context="selector"/>
 			</context>
 			<context name="comment" attribute="Comment" lineEndContext="#pop"></context>
+			<context name="selector" lineEndContext="#pop">
+				<RegExpr String="[^ \.]" context="#stay"/>
+				<DetectChar attribute="Class" char="." context="#pop!class"/>
+				<DetectChar attribute="Normal" char=" " context="#pop"/>
+			</context>
+			<context name="class" attribute="Class" lineEndContext="#pop">
+				<IncludeRules context="selector"/>
+			</context>
 		</contexts>
 		
 		<itemDatas>
@@ -156,7 +167,7 @@ Changelog:
 			<itemData name="Oct" defStyleNum="dsBaseN" spellChecking="false"/>
 			<itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false"/>
 			<itemData name="Id" defStyleNum="dsKeyword" spellChecking="false"/>
-			<itemData name="Class" defStyleNum="dsKeyword" spellChecking="false"/>
+			<itemData name="Class" defStyleNum="dsFloat" spellChecking="false"/>
 			<itemData name="Var" defStyleNum="dsString" spellChecking="false"/>
 			<itemData name="Comment" defStyleNum="dsComment" spellChecking="true"/>
 		</itemDatas>

--- a/jade.xml
+++ b/jade.xml
@@ -125,34 +125,9 @@ Changelog:
 			<item>append</item>
 			<item>prepend</item>
 		</list>
-		<list name="params">
-			<item>lang</item>
-			<item>href</item>
-			<item>type</item>
-			<item>id</item>
-			<item>class</item>
-			<item>src</item>
-			<item>rel</item>
-			<item>action</item>
-			<item>method</item>
-			<item>value</item>
-			<item>name</item>
-		</list>
-		
+
 		<contexts>
 			<context attribute="Normal" lineEndContext="#stay" name="Normal">
-				<!--
-				<Float attribute="Float" context="#stay"/>
-				<Int attribute="Decimal" context="#stay"/>
-				<HlCOct attribute="Oct" context="#stay"/>
-				<HlCHex attribute="Hex" context="#stay"/>
-				<keyword attribute="Params" context="#stay" casesensitive="true" String="params"/>
-				<RangeDetect attribute="String" char="'" char1="'" context="#pop"/>
-				<RangeDetect attribute="String" char="&quot;" char1="&quot;" context="#pop"/>
-				<RangeDetect attribute="Var" char="#" char1="}" context="#stay"/>
-				<RegExpr attribute="Id" String="#\w*" context="#stay"/>
-				<RegExpr attribute="Class" String="\.\w[^\s]*" context="#stay"/>
-				-->
 				<RegExpr String="^(\s+)(?=\S)" context="#stay" column="0"/><!-- Skip whitespace at start of line, so it doesn't get confused with whitespace used to separate selector from HTML -->
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
@@ -258,15 +233,9 @@ Changelog:
 			<itemData name="Value" defStyleNum="dsString" color="#a00" spellChecking="false" />
 			<itemData name="EntityRef" defStyleNum="dsDecVal" spellChecking="false" />
 			<itemData name="Error" defStyleNum="dsError" spellChecking="false" />
-			<itemData name="Params" defStyleNum="dsOther" spellChecking="false"/>
 			<itemData name="String" defStyleNum="dsString" spellChecking="false"/>
-			<itemData name="Decimal" defStyleNum="dsDecVal" spellChecking="false"/>
-			<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
-			<itemData name="Oct" defStyleNum="dsBaseN" spellChecking="false"/>
-			<itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false"/>
 			<itemData name="Id" defStyleNum="dsFloat" bold="1" spellChecking="false"/>
 			<itemData name="Class" defStyleNum="dsFloat" spellChecking="false"/>
-			<itemData name="Var" defStyleNum="dsString" spellChecking="false"/>
 			<itemData name="Comment" defStyleNum="dsComment" spellChecking="true"/>
 		</itemDatas>
 		

--- a/jade.xml
+++ b/jade.xml
@@ -105,7 +105,7 @@ Changelog:
 			<item>each</item>
 			<item>for</item>
 			<item>else</item>
-			<item>yeild</item>
+			<item>yield</item>
 			<item>mixin</item>
 		</list>
 		<list name="javascript-keywords">

--- a/jade.xml
+++ b/jade.xml
@@ -133,8 +133,6 @@ Changelog:
 				<Int attribute="Decimal" context="#stay"/>
 				<HlCOct attribute="Oct" context="#stay"/>
 				<HlCHex attribute="Hex" context="#stay"/>
-				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
-				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<keyword attribute="Params" context="#stay" casesensitive="true" String="params"/>
 				<RangeDetect attribute="String" char="'" char1="'" context="#pop"/>
 				<RangeDetect attribute="String" char="&quot;" char1="&quot;" context="#pop"/>
@@ -142,6 +140,8 @@ Changelog:
 				<RegExpr attribute="Id" String="#\w*" context="#stay"/>
 				<RegExpr attribute="Class" String="\.\w[^\s]*" context="#stay"/>
 				-->
+				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
+				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<IncludeRules context="selector"/>
 			</context>
@@ -162,8 +162,8 @@ Changelog:
 		
 		<itemDatas>
 			<itemData name="Normal" defStyleNum="dsNormal" spellChecking="false"/>
-			<itemData name="Keyword" defStyleNum="dsKeyword" spellChecking="false"/>
-			<itemData name="Tags" defStyleNum="dsOther" spellChecking="false"/>
+			<itemData name="Keyword" defStyleNum="dsKeyword" italic="true" spellChecking="false"/>
+			<itemData name="Tags" defStyleNum="dsKeyword" spellChecking="false"/>
 			<itemData name="Params" defStyleNum="dsOther" spellChecking="false"/>
 			<itemData name="String" defStyleNum="dsNormal" spellChecking="false"/>
 			<itemData name="Decimal" defStyleNum="dsDecVal" spellChecking="false"/>

--- a/jade.xml
+++ b/jade.xml
@@ -100,17 +100,11 @@ Changelog:
 			<item>tt</item>
 			<item>u</item>
 			<item>ul</item>
-			<item>doctype</item>
 		</list>
 		<list name="keywords">
 			<item>each</item>
 			<item>for</item>
 			<item>else</item>
-			<item>extends</item>
-			<item>block</item>
-			<item>appends</item>
-			<item>prepend</item>
-			<item>include</item>
 			<item>yeild</item>
 			<item>mixin</item>
 		</list>
@@ -121,6 +115,15 @@ Changelog:
 			<item>case</item>
 			<item>when</item>
 			<item>while</item>
+		</list>
+		<list name="string-keywords">
+			<!-- keywords which are followed by plain text strings -->
+			<item>doctype</item>
+			<item>include</item>
+			<item>extends</item>
+			<item>block</item>
+			<item>append</item>
+			<item>prepend</item>
 		</list>
 		<list name="params">
 			<item>lang</item>
@@ -154,6 +157,7 @@ Changelog:
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<keyword attribute="Keyword" context="javascript-line" firstNonSpace="true" String="javascript-keywords"/>
+				<keyword attribute="Keyword" context="string-line" firstNonSpace="true" String="string-keywords"/>
 				<RegExpr String="//$" context="comment-block" attribute="Comment"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>
@@ -243,6 +247,7 @@ Changelog:
 			<context name="html-line" attribute="Normal" lineEndContext="#pop">
 				<IncludeRules context="##HTML"/>
 			</context>
+			<context name="string-line" attribute="String" lineEndContext="#pop"></context>
 		</contexts>
 		
 		<itemDatas>
@@ -254,7 +259,7 @@ Changelog:
 			<itemData name="EntityRef" defStyleNum="dsDecVal" spellChecking="false" />
 			<itemData name="Error" defStyleNum="dsError" spellChecking="false" />
 			<itemData name="Params" defStyleNum="dsOther" spellChecking="false"/>
-			<itemData name="String" defStyleNum="dsNormal" spellChecking="false"/>
+			<itemData name="String" defStyleNum="dsString" spellChecking="false"/>
 			<itemData name="Decimal" defStyleNum="dsDecVal" spellChecking="false"/>
 			<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
 			<itemData name="Oct" defStyleNum="dsBaseN" spellChecking="false"/>

--- a/jade.xml
+++ b/jade.xml
@@ -150,6 +150,7 @@ Changelog:
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>
 				<StringDetect String="- " firstNonSpace="true" context="javascript-line"/>
 				<LineContinue context="plaintext-block" char="."/>
+				<LineContinue context="code-block" firstNonSpace="true" char="-"/>
 				<IncludeRules context="selector"/>
 			</context>
 			
@@ -188,6 +189,14 @@ Changelog:
 			<context name="plaintext-block-line" attribute="Normal" lineEndContext="#stay" dynamic="true">
 				<RegExpr attribute="Normal" String="^%1" context="#stay" column="0" dynamic="true"/>
 				<RegExpr attribute="Normal" String="^(.|$)" lookAhead="true" context="#pop#pop" column="0"/>
+			</context>
+			<context name="code-block" attribute="Normal">
+				<RegExpr attribute="Normal" String="^(\s+)(?=\S)" context="code-block-line" column="0"/>
+			</context>
+			<context name="code-block-line" attribute="Normal" lineEndContext="#stay" dynamic="true">
+				<RegExpr attribute="Normal" String="^%1" context="#stay" column="0" dynamic="true"/>
+				<RegExpr attribute="Normal" String="^(.|$)" lookAhead="true" context="#pop#pop" column="0"/>
+				<IncludeRules context="##JavaScript"/>
 			</context>
 			
 			<context name="selector" lineEndContext="#pop">

--- a/jade.xml
+++ b/jade.xml
@@ -147,11 +147,15 @@ Changelog:
 			</context>
 			<context name="comment" attribute="Comment" lineEndContext="#pop"></context>
 			<context name="selector" lineEndContext="#pop">
-				<RegExpr String="[^ \.]" context="#stay"/>
+				<RegExpr String="[^ \.#]" context="#stay"/>
 				<DetectChar attribute="Class" char="." context="#pop!class"/>
+				<DetectChar attribute="Id" char="#" context="#pop!id"/>
 				<DetectChar attribute="Normal" char=" " context="#pop"/>
 			</context>
 			<context name="class" attribute="Class" lineEndContext="#pop">
+				<IncludeRules context="selector"/>
+			</context>
+			<context name="id" attribute="Id" lineEndContext="#pop">
 				<IncludeRules context="selector"/>
 			</context>
 		</contexts>
@@ -166,7 +170,7 @@ Changelog:
 			<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
 			<itemData name="Oct" defStyleNum="dsBaseN" spellChecking="false"/>
 			<itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false"/>
-			<itemData name="Id" defStyleNum="dsKeyword" spellChecking="false"/>
+			<itemData name="Id" defStyleNum="dsFloat" bold="1" spellChecking="false"/>
 			<itemData name="Class" defStyleNum="dsFloat" spellChecking="false"/>
 			<itemData name="Var" defStyleNum="dsString" spellChecking="false"/>
 			<itemData name="Comment" defStyleNum="dsComment" spellChecking="true"/>

--- a/jade.xml
+++ b/jade.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE language SYSTEM "language.dtd">
+<!DOCTYPE language SYSTEM "language.dtd"
+[
+<!ENTITY name    "[A-Za-z_:][\w.:_-]*">
+<!ENTITY entref  "&amp;(#[0-9]+|#[xX][0-9A-Fa-f]+|&name;);">
+]>
 
 <!--
 
@@ -143,12 +147,38 @@ Changelog:
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
+				<DetectChar char="(" attribute="Normal" context="Attributes"/>
 				<LineContinue context="plaintext-block" char="."/>
 				<IncludeRules context="selector"/>
 			</context>
 			
 			<context name="comment" attribute="Comment" lineEndContext="#pop">
 				<IncludeRules context="##Alerts"/>
+			</context>
+			
+			<context name="Attributes" attribute="Normal" lineEndContext="#stay">
+				<RegExpr attribute="Attribute" context="#stay" String="&name;" />
+				<DetectChar attribute="Attribute" context="Value" char="=" />
+				<DetectChar context="#stay" char="," />
+				<DetectSpaces />
+				<DetectChar attribute="Normal" context="#pop" char=")" />
+			</context>
+			<context name="Value" attribute="Normal" lineEndContext="#stay" fallthrough="true" fallthroughContext="#pop">
+				<DetectChar attribute="Value" context="Value DQ" char="&quot;" />
+				<DetectChar attribute="Value" context="Value SQ" char="&apos;" />
+				<DetectSpaces />
+			</context>
+			<context name="Value DQ" attribute="Value" lineEndContext="#stay">
+				<DetectChar attribute="Value" context="#pop#pop" char="&quot;" />
+				<IncludeRules context="FindEntityRefs" />
+			</context>
+			<context name="Value SQ" attribute="Value" lineEndContext="#stay">
+				<DetectChar attribute="Value" context="#pop#pop" char="&apos;" />
+				<IncludeRules context="FindEntityRefs" />
+			</context>
+			<context name="FindEntityRefs" attribute="Normal" lineEndContext="#stay">
+				<RegExpr attribute="EntityRef" context="#stay" String="&entref;" />
+				<AnyChar attribute="Error" context="#stay" String="&amp;&lt;" />
 			</context>
 			
 			<context name="plaintext-block" attribute="Normal">
@@ -177,6 +207,10 @@ Changelog:
 			<itemData name="Normal" defStyleNum="dsNormal" spellChecking="false"/>
 			<itemData name="Keyword" defStyleNum="dsKeyword" italic="true" spellChecking="false"/>
 			<itemData name="Tags" defStyleNum="dsKeyword" spellChecking="false"/>
+			<itemData name="Attribute" defStyleNum="dsOthers" spellChecking="false" />
+			<itemData name="Value" defStyleNum="dsString" color="#a00" spellChecking="false" />
+			<itemData name="EntityRef" defStyleNum="dsDecVal" spellChecking="false" />
+			<itemData name="Error" defStyleNum="dsError" spellChecking="false" />
 			<itemData name="Params" defStyleNum="dsOther" spellChecking="false"/>
 			<itemData name="String" defStyleNum="dsNormal" spellChecking="false"/>
 			<itemData name="Decimal" defStyleNum="dsDecVal" spellChecking="false"/>

--- a/jade.xml
+++ b/jade.xml
@@ -147,6 +147,7 @@ Changelog:
 				<RegExpr String="^(\s+)(?=\S)" context="#stay" column="0"/><!-- Skip whitespace at start of line, so it doesn't get confused with whitespace used to separate selector from HTML -->
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
+				<RegExpr String="//$" context="comment-block" attribute="Comment"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>
 				<DetectChar char="&lt;" context="html-line" lookAhead="true"/>
@@ -199,6 +200,14 @@ Changelog:
 				<RegExpr attribute="Normal" String="^%1" context="#stay" column="0" dynamic="true"/>
 				<RegExpr attribute="Normal" String="^(.|$)" lookAhead="true" context="#pop#pop" column="0"/>
 				<IncludeRules context="##JavaScript"/>
+			</context>
+			<context name="comment-block" attribute="Comment">
+				<RegExpr attribute="Normal" String="^(\s+)(?=\S)" context="comment-block-line" column="0"/>
+			</context>
+			<context name="comment-block-line" attribute="Comment" lineEndContext="#stay" dynamic="true">
+				<RegExpr attribute="Normal" String="^%1" context="#stay" column="0" dynamic="true"/>
+				<RegExpr attribute="Normal" String="^(.|$)" lookAhead="true" context="#pop#pop" column="0"/>
+				<IncludeRules context="##Alerts"/>
 			</context>
 			
 			<context name="selector" lineEndContext="#pop">

--- a/jade.xml
+++ b/jade.xml
@@ -150,9 +150,9 @@ Changelog:
 			<itemData name="Params" defStyleNum="dsOther" spellChecking="false"/>
 			<itemData name="String" defStyleNum="dsNormal" spellChecking="false"/>
 			<itemData name="Decimal" defStyleNum="dsDecVal" spellChecking="false"/>
-      <itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
-      <itemData name="Oct" defStyleNum="dsBaseN" spellChecking="false"/>
-      <itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false"/>
+			<itemData name="Float" defStyleNum="dsFloat" spellChecking="false"/>
+			<itemData name="Oct" defStyleNum="dsBaseN" spellChecking="false"/>
+			<itemData name="Hex" defStyleNum="dsBaseN" spellChecking="false"/>
 			<itemData name="Id" defStyleNum="dsKeyword" spellChecking="false"/>
 			<itemData name="Class" defStyleNum="dsKeyword" spellChecking="false"/>
 			<itemData name="Var" defStyleNum="dsString" spellChecking="false"/>
@@ -162,9 +162,9 @@ Changelog:
 			<indentation mode="python"/>
 			<folding indentationsensitive="1"/>
 			<comments>
-				<comment name="singleLine" start="//" />
+				<comment name="singleLine" start="//"/>
 			</comments>
-			<keywords casesensitive="1" />
+			<keywords casesensitive="1"/>
 		</general>
 	</highlighting>
 </language>

--- a/jade.xml
+++ b/jade.xml
@@ -148,6 +148,7 @@ Changelog:
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>
+				<StringDetect String="- " firstNonSpace="true" context="javascript-line"/>
 				<LineContinue context="plaintext-block" char="."/>
 				<IncludeRules context="selector"/>
 			</context>
@@ -190,16 +191,24 @@ Changelog:
 			</context>
 			
 			<context name="selector" lineEndContext="#pop">
-				<RegExpr String="[^ \.#]" context="#stay"/>
+				<RegExpr String="[^ \.#=!]" context="#stay"/>
 				<DetectChar attribute="Class" char="." context="#pop!class"/>
 				<DetectChar attribute="Id" char="#" context="#pop!id"/>
 				<DetectChar attribute="Normal" char=" " context="#pop"/>
+				<StringDetect String="= "  context="javascript-line-from-selector"/>
+				<StringDetect String="!= " context="javascript-line-from-selector"/>
 			</context>
 			<context name="class" attribute="Class" lineEndContext="#pop">
 				<IncludeRules context="selector"/>
 			</context>
 			<context name="id" attribute="Id" lineEndContext="#pop">
 				<IncludeRules context="selector"/>
+			</context>
+			<context name="javascript-line-from-selector" attribute="Normal" lineEndContext="#pop#pop">
+				<IncludeRules context="##JavaScript"/>
+			</context>
+			<context name="javascript-line" attribute="Normal" lineEndContext="#pop">
+				<IncludeRules context="##JavaScript"/>
 			</context>
 		</contexts>
 		

--- a/jade.xml
+++ b/jade.xml
@@ -144,8 +144,6 @@ Changelog:
 			<item>wbr</item>
 		</list>
 		<list name="keywords">
-			<item>each</item>
-			<item>for</item>
 			<item>else</item>
 			<item>yield</item>
 			<item>mixin</item>
@@ -157,6 +155,13 @@ Changelog:
 			<item>case</item>
 			<item>when</item>
 			<item>while</item>
+		</list>
+		<list name="each-keywords">
+			<item>each</item>
+			<item>for</item>
+		</list>
+		<list name="in-keyword">
+			<item>in</item>
 		</list>
 		<list name="string-keywords">
 			<!-- keywords which are followed by plain text strings -->
@@ -175,6 +180,7 @@ Changelog:
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<keyword attribute="Keyword" context="javascript-line" firstNonSpace="true" String="javascript-keywords"/>
 				<keyword attribute="Keyword" context="string-line" firstNonSpace="true" String="string-keywords"/>
+				<keyword attribute="Keyword" context="each" firstNonSpace="true" String="each-keywords"/>
 				<RegExpr String="//$" context="comment-block" attribute="Comment"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>
@@ -183,6 +189,10 @@ Changelog:
 				<LineContinue context="plaintext-block" char="."/>
 				<LineContinue context="code-block" firstNonSpace="true" char="-"/>
 				<IncludeRules context="selector"/>
+			</context>
+			
+			<context name="each" attribute="Normal" lineEndContext="#pop">
+				<StringDetect String=" in " attribute="Keyword" context="javascript-line-from-selector"/>
 			</context>
 			
 			<context name="comment" attribute="Comment" lineEndContext="#pop">

--- a/jade.xml
+++ b/jade.xml
@@ -145,7 +145,9 @@ Changelog:
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<IncludeRules context="selector"/>
 			</context>
-			<context name="comment" attribute="Comment" lineEndContext="#pop"></context>
+			<context name="comment" attribute="Comment" lineEndContext="#pop">
+				<IncludeRules context="##Alerts"/>
+			</context>
 			<context name="selector" lineEndContext="#pop">
 				<RegExpr String="[^ \.#]" context="#stay"/>
 				<DetectChar attribute="Class" char="." context="#pop!class"/>

--- a/jade.xml
+++ b/jade.xml
@@ -144,6 +144,7 @@ Changelog:
 				<RegExpr attribute="Id" String="#\w*" context="#stay"/>
 				<RegExpr attribute="Class" String="\.\w[^\s]*" context="#stay"/>
 				-->
+				<RegExpr String="^(\s+)(?=\S)" context="#stay" column="0"/><!-- Skip whitespace at start of line, so it doesn't get confused with whitespace used to separate selector from HTML -->
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
@@ -201,10 +202,10 @@ Changelog:
 			</context>
 			
 			<context name="selector" lineEndContext="#pop">
-				<RegExpr String="[^ \.#=!]" context="#stay"/>
+				<RegExpr String="[^\s\.#=!]" context="#stay"/>
 				<DetectChar attribute="Class" char="." context="#pop!class"/>
 				<DetectChar attribute="Id" char="#" context="#pop!id"/>
-				<DetectChar attribute="Normal" char=" " context="#pop"/>
+				<RegExpr String="\s" context="html-line-from-selector"/>
 				<StringDetect String="= "  context="javascript-line-from-selector"/>
 				<StringDetect String="!= " context="javascript-line-from-selector"/>
 			</context>
@@ -219,6 +220,9 @@ Changelog:
 			</context>
 			<context name="javascript-line" attribute="Normal" lineEndContext="#pop">
 				<IncludeRules context="##JavaScript"/>
+			</context>
+			<context name="html-line-from-selector" attribute="Normal" lineEndContext="#pop#pop">
+				<IncludeRules context="##HTML"/>
 			</context>
 			<context name="html-line" attribute="Normal" lineEndContext="#pop">
 				<IncludeRules context="##HTML"/>

--- a/jade.xml
+++ b/jade.xml
@@ -20,28 +20,45 @@ Changelog:
 		<list name="tags">
 			<item>a</item>
 			<item>applet</item>
+			<item>abbr</item>
+			<item>address</item>
 			<item>area</item>
+			<item>article</item>
+			<item>aside</item>
+			<item>audio</item>
 			<item>b</item>
+			<item>base</item>
+			<item>bdi</item>
+			<item>bdo</item>
 			<item>blockquote</item>
 			<item>body</item>
 			<item>br</item>
 			<item>button</item>
+			<item>canvas</item>
 			<item>caption</item>
 			<item>center</item>
 			<item>cite</item>
 			<item>code</item>
 			<item>col</item>
 			<item>colgroup</item>
+			<item>data</item>
+			<item>datalist</item>
 			<item>dd</item>
 			<item>del</item>
+			<item>details</item>
 			<item>dfn</item>
 			<item>dir</item>
+			<item>dialog</item>
 			<item>div</item>
 			<item>dl</item>
 			<item>dt</item>
 			<item>em</item>
+			<item>embed</item>
 			<item>fieldset</item>
 			<item>font</item>
+			<item>figcaption</item>
+			<item>figure</item>
+			<item>footer</item>
 			<item>form</item>
 			<item>frame</item>
 			<item>frameset</item>
@@ -52,6 +69,8 @@ Changelog:
 			<item>h5</item>
 			<item>h6</item>
 			<item>head</item>
+			<item>header</item>
+			<item>hgroup</item>
 			<item>hr</item>
 			<item>html</item>
 			<item>i</item>
@@ -61,45 +80,68 @@ Changelog:
 			<item>ins</item>
 			<item>isindex</item>
 			<item>kbd</item>
+			<item>keygen</item>
 			<item>label</item>
 			<item>legend</item>
 			<item>li</item>
 			<item>link</item>
+			<item>main</item>
 			<item>map</item>
+			<item>mark</item>
 			<item>menu</item>
+			<item>menuitem</item>
 			<item>meta</item>
 			<item>noframes</item>
+			<item>meter</item>
+			<item>nav</item>
 			<item>noscript</item>
 			<item>object</item>
 			<item>ol</item>
 			<item>optgroup</item>
 			<item>option</item>
+			<item>output</item>
 			<item>p</item>
 			<item>param</item>
 			<item>pre</item>
+			<item>progress</item>
 			<item>q</item>
+			<item>rb</item>
+			<item>rp</item>
+			<item>rt</item>
+			<item>rtc</item>
+			<item>ruby</item>
 			<item>s</item>
 			<item>samp</item>
 			<item>script</item>
+			<item>section</item>
 			<item>select</item>
 			<item>small</item>
+			<item>source</item>
 			<item>span</item>
 			<item>strike</item>
+			<item>strong</item>
 			<item>style</item>
 			<item>sub</item>
+			<item>summary</item>
 			<item>sup</item>
 			<item>table</item>
 			<item>tbody</item>
 			<item>td</item>
+			<item>template</item>
 			<item>textarea</item>
 			<item>tfoot</item>
 			<item>th</item>
 			<item>thead</item>
+			<item>time</item>
 			<item>title</item>
 			<item>tr</item>
 			<item>tt</item>
+			<item>track</item>
 			<item>u</item>
 			<item>ul</item>
+			<item>var</item>
+			<item>video</item>
+			<item>wbr</item>
 		</list>
 		<list name="keywords">
 			<item>each</item>

--- a/jade.xml
+++ b/jade.xml
@@ -148,6 +148,7 @@ Changelog:
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>
+				<DetectChar char="&lt;" context="html-line" lookAhead="true"/>
 				<StringDetect String="- " firstNonSpace="true" context="javascript-line"/>
 				<LineContinue context="plaintext-block" char="."/>
 				<LineContinue context="code-block" firstNonSpace="true" char="-"/>
@@ -218,6 +219,9 @@ Changelog:
 			</context>
 			<context name="javascript-line" attribute="Normal" lineEndContext="#pop">
 				<IncludeRules context="##JavaScript"/>
+			</context>
+			<context name="html-line" attribute="Normal" lineEndContext="#pop">
+				<IncludeRules context="##HTML"/>
 			</context>
 		</contexts>
 		

--- a/jade.xml
+++ b/jade.xml
@@ -105,9 +105,7 @@ Changelog:
 		<list name="keywords">
 			<item>each</item>
 			<item>for</item>
-			<item>if</item>
 			<item>else</item>
-			<item>unless</item>
 			<item>extends</item>
 			<item>block</item>
 			<item>appends</item>
@@ -115,6 +113,14 @@ Changelog:
 			<item>include</item>
 			<item>yeild</item>
 			<item>mixin</item>
+		</list>
+		<list name="javascript-keywords">
+			<!-- keywords which are followed by JavaScript code -->
+			<item>if</item>
+			<item>unless</item>
+			<item>case</item>
+			<item>when</item>
+			<item>while</item>
 		</list>
 		<list name="params">
 			<item>lang</item>
@@ -147,6 +153,7 @@ Changelog:
 				<RegExpr String="^(\s+)(?=\S)" context="#stay" column="0"/><!-- Skip whitespace at start of line, so it doesn't get confused with whitespace used to separate selector from HTML -->
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
+				<keyword attribute="Keyword" context="javascript-line" firstNonSpace="true" String="javascript-keywords"/>
 				<RegExpr String="//$" context="comment-block" attribute="Comment"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 				<DetectChar char="(" attribute="Normal" context="Attributes"/>

--- a/jade.xml
+++ b/jade.xml
@@ -143,11 +143,22 @@ Changelog:
 				<keyword attribute="Tags" context="#stay" firstNonSpace="true" casesensitive="false" String="tags"/>
 				<keyword attribute="Keyword" context="#stay" firstNonSpace="true" String="keywords"/>
 				<StringDetect String="//" firstNonSpace="true" context="comment"/>
+				<LineContinue context="plaintext-block" char="."/>
 				<IncludeRules context="selector"/>
 			</context>
+			
 			<context name="comment" attribute="Comment" lineEndContext="#pop">
 				<IncludeRules context="##Alerts"/>
 			</context>
+			
+			<context name="plaintext-block" attribute="Normal">
+				<RegExpr attribute="Normal" String="^(\s+)(?=\S)" context="plaintext-block-line" column="0"/>
+			</context>
+			<context name="plaintext-block-line" attribute="Normal" lineEndContext="#stay" dynamic="true">
+				<RegExpr attribute="Normal" String="^%1" context="#stay" column="0" dynamic="true"/>
+				<RegExpr attribute="Normal" String="^(.|$)" lookAhead="true" context="#pop#pop" column="0"/>
+			</context>
+			
 			<context name="selector" lineEndContext="#pop">
 				<RegExpr String="[^ \.#]" context="#stay"/>
 				<DetectChar attribute="Class" char="." context="#pop!class"/>

--- a/jade.xml
+++ b/jade.xml
@@ -140,7 +140,9 @@ Changelog:
 				<RangeDetect attribute="Var" char="#" char1="}" context="#stay"/>
 				<RegExpr attribute="Id" String="#\w*" context="#stay"/>
 				<RegExpr attribute="Class" String="\.\w[^\s]*" context="#stay"/>
+				<StringDetect String="//" firstNonSpace="true" context="comment"/>
 			</context>
+			<context name="comment" attribute="Comment" lineEndContext="#pop"></context>
 		</contexts>
 		
 		<itemDatas>
@@ -156,6 +158,7 @@ Changelog:
 			<itemData name="Id" defStyleNum="dsKeyword" spellChecking="false"/>
 			<itemData name="Class" defStyleNum="dsKeyword" spellChecking="false"/>
 			<itemData name="Var" defStyleNum="dsString" spellChecking="false"/>
+			<itemData name="Comment" defStyleNum="dsComment" spellChecking="true"/>
 		</itemDatas>
 		
 		<general>

--- a/jade.xml
+++ b/jade.xml
@@ -12,10 +12,12 @@ Kate Jade syntax highlighting definition
 Changelog:
 
 - Version 1 by RangerMauve (RangerMauve@hotmail.com)
+- Version 2 by Julien Brunet (jules at scarabecus.fr) - added classes, ids, attributes, jade keywords, and more
+- Version 3 by Wolfgang Faust (wolfgangmcq@gmail.com) - Major rewrite; significantly improved highlighting.
 
 -->
 
-<language name="Jade" section="Scripts" version="1.9" kateversion="2.4" extensions="*.jade" author="julien brunet (jules at scarabecus.fr)" license="MIT">
+<language name="Jade" section="Scripts" version="1.9" kateversion="2.4" extensions="*.jade" author="Wolfgang Faust (wolfgangmcq@gmail.com)" license="MIT">
 	<highlighting>
 		<list name="tags">
 			<item>a</item>


### PR DESCRIPTION
I started out intending to make a few tweaks and ended up basically rewriting the entire highlighter.

I used the same styles as the default HTML and CSS highlighters, so classes, ids, attributes, etc. all have the same styles they would in an HTML or CSS document.

Before | After
--- | ---
![image](https://cloud.githubusercontent.com/assets/2261204/11670036/beebb1ce-9dcd-11e5-8ecf-6a32670f39fa.png) | ![image](https://cloud.githubusercontent.com/assets/2261204/11670151/4fa2f682-9dce-11e5-8338-038df2d6bea8.png)

