### PR TITLE
Moved Syntax from 'Script' to 'Markup' section (and fixed file extension seperator)

### DIFF
--- a/pug.xml
+++ b/pug.xml
@@ -14,7 +14,7 @@ Changelog:
 - Version 4 by Sébastien Demanou (demsking@gmail.com) - change jade to pug
 -->
 
-<language name="Pug" section="Scripts" version="1.9" kateversion="2.4" extensions="*.pug,*.jade" author="Wolfgang Faust (wolfgangmcq@gmail.com)" license="MIT">
+<language name="Pug" section="Markup" version="1.9" kateversion="2.4" extensions="*.pug;*.jade" author="Wolfgang Faust (wolfgangmcq@gmail.com)" license="MIT">
 	<highlighting>
 		<list name="tags">
 			<item>a</item>


### PR DESCRIPTION
The Language used by PugJS is much more like SASS, Stylus, LaTeX, which are primarily markup languages, but they also have a huge "scriptability". Therefore I moved the Pug syntax highlighting in their neighbourhood.

... I also fixed the file extensions separator. It's an `;`, not a `,` :smile: 